### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -1,5 +1,8 @@
 name: Helm Lint
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/DramisInfo/platform-helm/security/code-scanning/14](https://github.com/DramisInfo/platform-helm/security/code-scanning/14)

In general, the fix is to add an explicit `permissions` block that grants only the minimal privileges needed by this workflow. This can be added at the top level (so it applies to all jobs) or within the `helm-lint` job. Since this workflow only checks out the repository and runs `helm lint`, it only needs read access to the repository contents; `contents: read` is sufficient and aligns with the CodeQL recommendation.

The best fix without changing functionality is to add a root-level `permissions` block beneath the `name` (or beneath `on:`) specifying `contents: read`. This documents the permission requirements and prevents the `GITHUB_TOKEN` from defaulting to broader access. Concretely, in `.github/workflows/helm-lint.yaml`, insert:

```yaml
permissions:
  contents: read
```

near the top of the file, so it applies to all jobs in this workflow. No other steps, actions, or behavior need to change, and no imports or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
