### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-chart-combinations.yaml
+++ b/.github/workflows/test-chart-combinations.yaml
@@ -1,5 +1,8 @@
 name: Test Chart Combinations
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/DramisInfo/platform-helm/security/code-scanning/13](https://github.com/DramisInfo/platform-helm/security/code-scanning/13)

In general, the fix is to explicitly define a `permissions:` block to restrict the GITHUB_TOKEN to the minimal scopes required. For this workflow, both jobs only need to read the repository contents (for checkout) and do not interact with pull requests or other resources, so `contents: read` at the workflow (top) level is sufficient. Adding it at the root will apply to all jobs that don’t override `permissions`.

Concretely, edit `.github/workflows/test-chart-combinations.yaml` and insert a root‑level `permissions:` block after the `name:` and before the `on:` section. This will not change existing functionality because `actions/checkout` works fine with `contents: read` and the remaining steps only run local commands. No changes are required inside individual jobs, and no imports or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
