### PR TITLE
fix(gatekeeper): disable native validation bootstrap path + pin policy library

### DIFF
--- a/platform-core/templates/argo-applications/gatekeeper/gatekeeper.yaml
+++ b/platform-core/templates/argo-applications/gatekeeper/gatekeeper.yaml
@@ -38,6 +38,10 @@ spec:
           # Log each admission denial as structured JSON to the controller pod logs.
           # Alloy ships these to Loki when monitoring is enabled.
           logDenies: {{ .Values.bootstrap.monitoring.enabled }}
+          # Disable the K8s-native ValidatingAdmissionPolicy integration during bootstrap.
+          # We keep classic webhook-based Gatekeeper enforcement to avoid bootstrap deadlocks
+          # caused by early VAP/VAPBinding readiness ordering.
+          enableK8sNativeValidation: {{ .Values.bootstrap.gatekeeper.enableK8sNativeValidation | default false }}
           image:
             release: v3.22.0
           podAnnotations:
@@ -50,7 +54,8 @@ spec:
             prometheus.io/path: "/metrics"
     {{- if .Values.bootstrap.gatekeeper.policies.enabled }}
     - repoURL: "https://github.com/open-policy-agent/gatekeeper-library"
-      targetRevision: "master"
+      # Pinned commit SHA for deterministic policy templates (no floating branch).
+      targetRevision: "b5844698218a05cc253f6c475c62bb991325fd43"
       path: "library/pod-security-policy"
     {{- end }}
     {{- if .Values.bootstrap.gatekeeper.policies.enabled }}

--- a/platform-core/values.yaml
+++ b/platform-core/values.yaml
@@ -102,9 +102,13 @@ bootstrap:
     enabled: false
   gatekeeper:
     enabled: true
+    # Keep classic Gatekeeper webhook enforcement path for bootstrap safety.
+    # Set to true only after validating VAP/VAPBinding behavior in your cluster.
+    enableK8sNativeValidation: false
     policies:
       # Enable policies from the official Gatekeeper Library
       # Uses community-maintained ConstraintTemplates from https://github.com/open-policy-agent/gatekeeper-library
+      # Source is pinned in the Gatekeeper Application template for deterministic bootstrap
       enabled: true
       # Enforcement action: "deny" blocks violations, "dryrun" logs only
       enforcementAction: deny


### PR DESCRIPTION
## Why
Bootstrap can deadlock when Gatekeeper's Kubernetes-native validation path is enabled too early. We also had a mutable policy source (`gatekeeper-library@master`) that made bootstrap non-deterministic.

## What changed
- Disabled Gatekeeper Kubernetes-native validation path in bootstrap:
  - set `enableK8sNativeValidation` in Gatekeeper chart values object (default from platform values, now `false`)
- Added explicit platform value:
  - `bootstrap.gatekeeper.enableK8sNativeValidation: false`
- Replaced floating Gatekeeper Library ref:
  - `targetRevision: master` -> pinned commit `b5844698218a05cc253f6c475c62bb991325fd43`

## Validation
- `helm lint repos/platform-helm/platform-core`
- `helm template` of `platform-core` confirms:
  - `enableK8sNativeValidation: false` is rendered in Gatekeeper application source values
  - policy source is pinned to commit SHA
- Rendered Gatekeeper upstream chart with `enableK8sNativeValidation=false` confirms controller args include:
  - `--enable-k8s-native-validation=false`

## Rollback
- Revert this PR commit to restore previous behavior:
  - re-enable native path by setting value true
  - restore mutable `master` reference (not recommended)
