### PR TITLE
fix: disable terraform operator by default

### DIFF
--- a/platform-core/values.yaml
+++ b/platform-core/values.yaml
@@ -90,7 +90,7 @@ bootstrap:
       # Vault URL used by the ClusterSecretStore
       sharedAkvUrl: "https://akv-dramisinfo-shared.vault.azure.net/"
   terraformOperator:
-    enabled: true
+    enabled: false
   externalSecretOperator:
     enabled: true
   cnpg:


### PR DESCRIPTION
## Summary
- Disable the Terraform Operator platform-core default so clusters opt in explicitly.

## Validation
- Parsed platform-core/values.yaml with PyYAML and confirmed bootstrap.terraformOperator.enabled is false.
- helm CLI is not installed on the Hermes host, so helm lint/template could not be run locally.