### PR TITLE
feat(platform-core): read-only hermes-sre ServiceAccount for agent cluster investigation

### DIFF
--- a/platform-core/templates/hermes-sre-rbac.yaml
+++ b/platform-core/templates/hermes-sre-rbac.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.bootstrap.hermesSre.enabled -}}
+# hermes-sre: read-only cluster investigation access for Hermes Agent
+# profiles. No secrets access, no write/delete/exec anywhere — this
+# ServiceAccount's token is meant to be handed to an autonomous LLM
+# sandbox, so its blast radius is deliberately capped at "look, don't
+# touch." See DramisInfo/platform-helm PR that introduced this file for
+# the full rationale (avoiding forwarding the admin kubeconfig or the
+# homelab host's SSH key into an agent sandbox).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hermes-sre
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hermes-sre-readonly
+  namespace: hermes-sre
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hermes-sre-readonly-token
+  namespace: hermes-sre
+  annotations:
+    kubernetes.io/service-account.name: hermes-sre-readonly
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hermes-sre-readonly
+rules:
+  # Read-only. Never add "secrets" to any rule here.
+  - apiGroups: [""]
+    resources:
+      - pods
+      - pods/log
+      - events
+      - nodes
+      - services
+      - endpoints
+      - configmaps
+      - namespaces
+      - persistentvolumeclaims
+      - replicationcontrollers
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list"]
+  - apiGroups: ["argoproj.io"]
+    resources: ["applications", "applicationsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apiextensions.crossplane.io", "platform.dramisinfo.com"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hermes-sre-readonly
+subjects:
+  - kind: ServiceAccount
+    name: hermes-sre-readonly
+    namespace: hermes-sre
+roleRef:
+  kind: ClusterRole
+  name: hermes-sre-readonly
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/platform-core/values.yaml
+++ b/platform-core/values.yaml
@@ -161,6 +161,11 @@ bootstrap:
         storageClass: ""
   keda:
     enabled: true
+  hermesSre:
+    # Read-only cluster investigation access for Hermes Agent profiles
+    # (pods/logs/events/metrics/ArgoCD+Crossplane status). No secrets
+    # access, no write/delete/exec. Flip true once reviewed.
+    enabled: false
   k6Operator:
     # Deploy Grafana k6 Operator via Argo CD (grafana/k6-operator 4.4.1)
     # The k6 Operator enables application teams to automate distributed load testing


### PR DESCRIPTION
## Summary

Adds an opt-in (default `bootstrap.hermesSre.enabled: false`) read-only ServiceAccount + ClusterRole/Binding for a dedicated Hermes Agent profile to investigate cluster issues (crashing pods, failed deployments, etc.) without needing the admin kubeconfig or host SSH access.

## Why

Forwarding the cluster admin kubeconfig or the homelab host's SSH key into an autonomous LLM sandbox is too broad a blast radius for "go look at why this pod is crashing." This ClusterRole grants only `get`/`list`/`watch` on pods, pod logs, events, nodes, workloads, metrics, and ArgoCD/Crossplane status objects — **no `secrets` access anywhere, no write/delete/exec**.

## What it adds

- Namespace `hermes-sre`
- ServiceAccount `hermes-sre-readonly`
- A long-lived ServiceAccount token Secret (not the short-lived `TokenRequest` kind, so it survives as a standing credential)
- ClusterRole + ClusterRoleBinding, read-only

## Verification

- `helm lint platform-core/` — clean
- `helm template platform-core/ --set bootstrap.hermesSre.enabled=true` — renders all 5 resources correctly
- `helm template platform-core/` (default, disabled) — renders zero hermes-sre resources, confirming the toggle guard works
- Nothing applied to the live cluster directly — this is fully GitOps-managed so it survives cluster recreation

## Rollout

Merge, let ArgoCD sync `platform-core` with `hermesSre.enabled: false` (no-op), then flip to `true` in a follow-up once reviewed — or review inline here before merging with it already `true`, your call.
