### PR TITLE
docs: add docs/ folder with user guide and architecture

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,33 @@
+# platform-helm docs
+
+This folder holds the user guide and architecture documentation for the
+`platform-helm` repo. It complements (does not replace) the top-level
+[`README.md`](../README.md).
+
+## Contents
+
+- [`overview.md`](overview.md) — what this repo is, who uses it, when to
+  touch it, and where it fits in the DramisInfo platform stack.
+- [`architecture.md`](architecture.md) — how the chart, Argo CD
+  AppProjects, sync waves, and downstream components fit together.
+- [`user-guide.md`](user-guide.md) — day-to-day tasks: lint, render,
+  install, override values for a cluster, common operations, and
+  troubleshooting.
+- [`related-repos.md`](related-repos.md) — pointer list to sibling
+  DramisInfo repos in the home-lab platform stack.
+
+## How to navigate
+
+If you are new to the repo, start with `overview.md`, then read
+`architecture.md` to understand how `platform-core` delegates work to
+Argo CD. Use `user-guide.md` as a reference when running chart commands
+or editing cluster overrides. Use `related-repos.md` to find which
+neighboring repo owns a given concern (cluster bootstrap, Crossplane
+compositions, project workspaces, shared standards, CI workflows).
+
+## Scope of these docs
+
+These documents describe the `platform-core` Helm chart as it exists in
+this repository. They do not cover day-0 cluster bootstrap, Crossplane
+composition authoring, or workspace provisioning — those live in their
+own repos and are listed in `related-repos.md`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,130 @@
+# Architecture
+
+`platform-core` is intentionally thin at runtime. It runs once per
+cluster bootstrap (and once per `helm upgrade`) and renders Argo CD
+control-plane objects. After that, Argo CD is the source of truth for
+the platform layer.
+
+## Layered view
+
+```
+Cluster values file  →  Helm release (platform-core)  →  Argo CD
+                                                          │
+                                                          ├── AppProjects
+                                                          └── Applications
+                                                                │
+                                                                └── upstream
+                                                                    charts /
+                                                                    git sources
+```
+
+The chart does not deploy Gateway API, cert-manager, Crossplane, or
+Istio directly. It renders `Application` and `AppProject` CRDs into
+the `argocd` namespace. Argo CD then reconciles those CRDs and
+deploys the real workloads into their target namespaces.
+
+## AppProjects
+
+`templates/argocd-projects.yaml` defines six platform AppProjects,
+each pinned to `argocd.argoproj.io/sync-wave: "-200"` so they are
+created before the Applications they scope:
+
+- `platform-foundations` — security, policy, CRD bootstrapping, secret
+  management. Apps: `gateway-api`, `gatekeeper`, `cert-manager`,
+  `external-secret-operator`, `argo-events`.
+- `platform-networking` — service mesh, ingress, and API gateways.
+  Apps: `istio`, `envoy-gateway`.
+- `platform-observability` — metrics, logs, traces, dashboards, and
+  service-mesh observability. Apps: `prometheus`, `grafana`, `loki`,
+  `tempo`, `beyla`.
+- `platform-infra` — workload execution, scaling, data and event
+  plumbing. Apps: `keda`, `nats`, `cnpg`, `atlas`,
+  `terraform-operator`, `kubevela`, `k6-operator`.
+- `platform-product-workspaces` — discover `XProductWorkspace`
+  claims from `https://github.com/DramisInfo/*-workspace.git` via
+  ApplicationSet.
+- `platform-data` — Crossplane Compositions and provider plumbing,
+  installed alongside Crossplane.
+
+## Sync waves
+
+Component templates set `argocd.argoproj.io/sync-wave` annotations to
+order reconciliation. Reference points used by the chart:
+
+- `-200` — AppProjects (foundations, networking, observability,
+  infra, product-workspaces, data).
+- `-201` / `-200` — shared ConfigMap and namespace
+  (`platform-config.yaml`).
+- `-120` — Gatekeeper.
+- `-115` — Gateway API CRDs.
+- `-112` — Crossplane.
+- `-111` — Crossplane config / provider plumbing.
+- `-109` — Crossplane compositions.
+- `-107` — cert-manager.
+- `-100` — Istio.
+- `-90` — Prometheus, KEDA.
+- `-50` — NATS.
+
+When adding a new component, place it on a wave between its CRD
+providers and its consumers. Negative waves reconcile earlier.
+
+## Cluster identity
+
+`templates/platform-config.yaml` renders a ConfigMap (and Namespace)
+that downstream Argo CD Applications read for shared cluster identity:
+cluster name, Azure tenant / subscription / location, the
+`*.{cluster}.dramisinfo.com` host template, and related defaults.
+This avoids re-passing cluster identity through every Application's
+values.
+
+`global.clusterName` drives:
+
+- the wildcard host (`bootstrap.istio.host` resolves to
+  `*.{{ .Values.global.clusterName }}.dramisinfo.com` by default);
+- Azure resource naming (e.g. `rg-{clusterName}`,
+  `umi-{clusterName}-certmanager`);
+- NATS JetStream domain defaults when gateways are enabled;
+- the default Grafana TLS secret name
+  (`envoy-gateway-tls-{clusterName}`).
+
+## Crossplane-managed identities
+
+The chart does not provision workload identities directly. Instead:
+
+- The cert-manager user-assigned managed identity is created by
+  Crossplane (composition in `platform-crossplane-compositions`)
+  when `bootstrap.crossplane.certManagerIdentity.enabled` is set to
+  true via a cluster overlay patch. The cert-manager Application
+  template picks up the resulting client ID.
+- The External Secrets Operator identity and ClusterSecretStore are
+  similarly provisioned by Crossplane via
+  `bootstrap.crossplane.esoIdentity`. The shared Key Vault is
+  `akv-dramisinfo-shared`.
+
+This keeps cluster-bootstrap concerns out of Helm and lets
+Crossplane handle the Azure-side lifecycle.
+
+## Read-only investigation RBAC
+
+`templates/hermes-sre-rbac.yaml` renders a `hermes-sre-readonly`
+ServiceAccount plus ClusterRole, intended for autonomous agent
+sandboxes to investigate Argo CD and Crossplane status without write
+access. The role is intentionally narrow (pods, logs, events, nodes,
+Argo CD / Crossplane status). It must not be widened — no secrets, no
+write verbs, no `pods/exec`, no wildcard rules.
+
+## Gatekeeper posture
+
+Gatekeeper runs in `enforcementAction: deny` by default for the
+included policy library. Component templates add the required
+security context to satisfy the library: `runAsNonRoot: true`,
+`allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`,
+`seccompProfile.type: RuntimeDefault`. Switch to `dryrun` while
+validating a new policy or a new workload on the target cluster, then
+flip back to `deny`.
+
+## Argo CD itself is assumed
+
+The chart does not install Argo CD. Argo CD is expected to already
+exist in the `argocd` namespace on the target cluster, and
+`platform-core` is installed into that same namespace.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,90 @@
+# Overview
+
+`platform-helm` ships a single meta Helm chart, `platform-core`, that
+bootstraps a Kubernetes cluster's platform layer as Argo CD
+`Application` CRDs rather than as direct workloads. Argo CD owns the
+full lifecycle (install, upgrade, rollback, drift detection, prune,
+self-heal) of every component the chart enables.
+
+## What this repo contains
+
+```
+platform-helm/
+├── platform-core/                       the chart
+│   ├── Chart.yaml                       chart metadata (SemVer version)
+│   ├── values.yaml                      bootstrap.* toggles + cluster identity
+│   ├── README.md                        Grafana-specific value docs
+│   ├── GATEKEEPER-POLICIES.md           policy library behaviour, exclusions
+│   └── templates/
+│       ├── _helpers.tpl                 retry helpers
+│       ├── argocd-projects.yaml         six platform AppProjects
+│       ├── platform-config.yaml         shared cluster identity ConfigMap
+│       ├── hermes-sre-rbac.yaml         read-only SA for agent investigation
+│       └── argo-applications/<comp>/    one Argo CD Application per component
+├── .github/                             CI, release automation, agents, prompts
+├── README.md                            user-facing entry point
+└── CONTRIBUTING.md, SECURITY.md, LICENSE
+```
+
+The chart currently renders Argo CD Applications for, among others:
+Gateway API, Gatekeeper (with policy library), cert-manager,
+Crossplane, External Secrets Operator, Istio, Envoy Gateway, KEDA,
+NATS (with JetStream and optional gateway mesh), Argo Events, Atlas
+Operator, CloudNative-PG, Grafana, Loki, Tempo, Prometheus, Beyla,
+k6 Operator, KubeVela, and the Terraform Operator.
+
+## Who uses this repo
+
+- Platform engineers maintaining the DramisInfo platform stack.
+- Application teams that consume the resulting platform layer
+  (ingress, mesh, secrets, observability, data services) on their
+  product workspaces.
+- Operators bringing up a new cluster who need a known-good
+  composition of platform components.
+
+## When to touch it
+
+Touch this repo when you need to:
+
+- Add, remove, or upgrade a platform component.
+- Change the default `bootstrap.<component>.enabled` toggle for a new
+  cluster baseline.
+- Tune cluster identity (`global.clusterName`, `global.azure`),
+  ingress hosts (`bootstrap.istio.host`), Gatekeeper policy
+  enforcement, monitoring defaults, or NATS / JetStream settings.
+- Adjust sync-wave ordering between components (e.g., when adding a
+  new CRD-providing application that must land before its
+  dependents).
+- Update pinned upstream chart or source revisions.
+
+Do not touch this repo to deploy application workloads directly. All
+workloads — platform or product — belong behind an Argo CD
+`Application`. New platform capabilities go in as new component
+templates under `templates/argo-applications/<component>/` with a
+matching `bootstrap.<component>.enabled` toggle.
+
+## When not to touch it
+
+- Cluster bootstrap, Proxmox, Azure Arc registration: handled by
+  `DramisInfo/home-lab`.
+- Crossplane Compositions and XRDs: handled by
+  `DramisInfo/platform-crossplane-compositions`.
+- Crossplane providers and functions: handled by
+  `DramisInfo/crossplane-providers-and-functions`.
+- Per-project tenant workspaces, RBAC, quotas, and ApplicationSets:
+  handled by `DramisInfo/platform-project-workspaces`.
+- Repo-wide conventions and policy documents: handled by
+  `DramisInfo/platform-standards`.
+- Shared CI workflows: handled by `DramisInfo/platform-workflows`.
+
+See [`related-repos.md`](related-repos.md) for the full list.
+
+## Release and versioning
+
+The chart follows SemVer on `platform-core/Chart.yaml`. Patch bumps
+for bug fixes and version-pin refreshes; minor bumps for new
+components, new value toggles, or non-breaking chart upgrades; major
+bumps for breaking changes. Releases are automated by
+release-please (`.github/workflows/release-please.yml`) and published
+as GitHub Releases with packaged chart artifacts by the chart-releaser
+workflow (`.github/workflows/release.yaml`).

--- a/docs/related-repos.md
+++ b/docs/related-repos.md
@@ -1,0 +1,27 @@
+# Related repos
+
+This repo is part of the DramisInfo home-lab platform stack. The
+other repos in the stack:
+
+- [DramisInfo/home-lab](https://github.com/DramisInfo/home-lab) —
+  Source of truth for cluster topology, hardware, network layout,
+  and high-level architecture decisions.
+- [DramisInfo/platform-tools](https://github.com/DramisInfo/platform-tools) —
+  Shared scripts, CLIs, and helper tooling used across the stack.
+- [DramisInfo/platform-helm](https://github.com/DramisInfo/platform-helm) —
+  The platform-core Helm chart (umbrella chart that composes all
+  platform services).
+- [DramisInfo/platform-crossplane-compositions](https://github.com/DramisInfo/platform-crossplane-compositions) —
+  Crossplane CompositeResourceDefinitions and Compositions that
+  project Azure resources into the cluster via Azure Arc.
+- [DramisInfo/platform-project-workspaces](https://github.com/DramisInfo/platform-project-workspaces) —
+  Per-project tenant workspaces: namespaces, RBAC, quotas, and
+  Argo CD ApplicationSets scoped to a single project.
+- [DramisInfo/platform-standards](https://github.com/DramisInfo/platform-standards) —
+  Repo-wide conventions, schemas, and policy documents referenced
+  by all other repos.
+- [DramisInfo/platform-workflows](https://github.com/DramisInfo/platform-workflows) —
+  Reusable GitHub Actions workflows and composite actions.
+- [DramisInfo/crossplane-providers-and-functions](https://github.com/DramisInfo/crossplane-providers-and-functions) —
+  Custom Crossplane providers and composition functions used by
+  the platform-crossplane-compositions stack.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,178 @@
+# User guide
+
+Day-to-day tasks for working with the `platform-core` chart: linting,
+rendering, installing, configuring per-cluster overrides, common
+operations, and troubleshooting.
+
+## Prerequisites
+
+- Helm v3 (CI pins `azure/setup-helm@v5` to `v3.14.4`).
+- A Kubernetes cluster context.
+- Argo CD already installed in the `argocd` namespace on the target
+  cluster. The chart does not install Argo CD.
+- A cluster-specific values file (see "Per-cluster values" below).
+
+## Lint and render
+
+Always lint and render before opening a PR or applying a change to a
+running cluster:
+
+```bash
+helm lint platform-core
+helm template platform-core ./platform-core                # defaults
+helm template platform-core ./platform-core -f my-values.yaml
+```
+
+Lint catches schema, template, and `values.yaml` issues locally. Render
+catches sync-wave ordering and reference problems that lint does not
+see.
+
+## Install
+
+The chart installs into the `argocd` namespace alongside Argo CD:
+
+```bash
+helm install platform-core ./platform-core \
+  -n argocd \
+  -f my-values.yaml
+```
+
+To upgrade in place after a value change:
+
+```bash
+helm upgrade --install platform-core ./platform-core \
+  -n argocd \
+  -f my-values.yaml
+```
+
+After any change, confirm Argo CD picked up the rendered Applications
+and that they reconcile in wave order.
+
+## Per-cluster values
+
+Keep cluster overrides in a values file under your platform-tools or
+home-lab overlay (see [`related-repos.md`](related-repos.md)). A
+typical cluster override looks like:
+
+```yaml
+global:
+  clusterName: "cace-1-dev"
+
+bootstrap:
+  istio:
+    host: "*.cace-1-dev.dramisinfo.com"
+
+  gatekeeper:
+    policies:
+      # Start in dryrun while you validate new policies on this cluster.
+      enforcementAction: dryrun
+```
+
+Common overrides:
+
+| Concern                                  | Key                                                           |
+| ---------------------------------------- | ------------------------------------------------------------- |
+| Cluster name and Azure identity         | `global.clusterName`, `global.azure`                          |
+| Per-cluster cert-manager UMI (via XP)    | `bootstrap.crossplane.certManagerIdentity.enabled`           |
+| Per-cluster ESO UMI and ClusterSecretStore | `bootstrap.crossplane.esoIdentity`                         |
+| Gatekeeper mode                          | `bootstrap.gatekeeper.policies.enforcementAction`             |
+| Wildcard ingress host                    | `bootstrap.istio.host`                                        |
+| Monitoring defaults                      | `bootstrap.monitoring.{grafana,loki,tempo}`                  |
+| NATS JetStream domain / gateways         | `bootstrap.nats.jetstream`, `bootstrap.nats.gateway`         |
+| Terraform Operator opt-in                | `bootstrap.terraformOperator.enabled`                        |
+
+Never put credentials, tokens, or API keys in a values file. Use
+External Secrets Operator against `akv-dramisinfo-shared` instead.
+
+## Common operations
+
+### Add a new platform component
+
+1. Create `platform-core/templates/argo-applications/<component>/<component>.yaml`
+   with the Argo CD `Application` manifest.
+2. Wrap the file in `{{- if .Values.bootstrap.<component>.enabled -}}`
+   so the toggle gates the render.
+3. Add a default block `bootstrap.<component>: { enabled: false, ... }`
+   in `values.yaml` with inline documentation.
+4. Set `argocd.argoproj.io/sync-wave` based on dependency order
+   (see [`architecture.md`](architecture.md) for reference points).
+5. Pin `targetRevision` to an exact chart version or commit. Never
+   `latest` or a floating branch.
+6. Apply the required Gatekeeper security context to every pod:
+   `runAsNonRoot: true`, `allowPrivilegeEscalation: false`,
+   `capabilities.drop: [ALL]`, `seccompProfile.type: RuntimeDefault`.
+7. Add the component's destination namespace to the matching
+   `AppProject` in `templates/argocd-projects.yaml`.
+8. Bump `platform-core/Chart.yaml` per SemVer.
+
+### Upgrade an upstream chart
+
+1. Bump `targetRevision` in the relevant `templates/argo-applications/<component>/<component>.yaml`.
+2. If the new chart has a breaking values schema, update the values
+   passed via the template.
+3. Run `helm lint platform-core` and `helm template platform-core
+   ./platform-core -f my-values.yaml`.
+4. Bump `platform-core/Chart.yaml` (patch for version pins, minor for
+   a real chart upgrade).
+
+### Switch Gatekeeper to dryrun for validation
+
+```yaml
+bootstrap:
+  gatekeeper:
+    policies:
+      enforcementAction: dryrun
+```
+
+Apply, observe violations in Gatekeeper logs and audit events, then
+flip back to `deny`.
+
+### Enable the read-only agent SA
+
+`bootstrap.hermesSre.enabled` is `false` by default. Set it to `true`
+on clusters where you want a Hermes / agent sandbox to investigate
+Argo CD and Crossplane status. Do not widen the resulting role.
+
+## Troubleshooting
+
+- **Helm reports an unknown `Application` kind.** Argo CD is not
+  installed on the target cluster, or you installed into the wrong
+  namespace. Install Argo CD into `argocd` and re-run `helm install`.
+- **A component does not render.** Confirm the case-sensitive
+  `bootstrap.<component>.enabled` key exists. Observability components
+  share `bootstrap.monitoring.enabled` — Grafana, Loki, Tempo, and
+  Beyla all flip with that one toggle.
+- **An Application stays OutOfSync or unhealthy.** Inspect its
+  AppProject, the pinned `targetRevision`, the destination namespace,
+  and the sync-wave applications that must complete first (e.g.,
+  Gateway API CRDs must land before cert-manager's Gateway API check,
+  Crossplane must land before its compositions, and so on).
+- **Gatekeeper blocks a new workload.** Add the required non-root
+  security context, drop all capabilities, and use the
+  `RuntimeDefault` seccomp profile. Validate in `dryrun` first.
+- **First bootstrap fails on a missing CRD.** Re-sync in wave order:
+  Gateway API → Crossplane → Crossplane compositions →
+  cert-manager → Istio → Prometheus / KEDA → NATS.
+- **Cert-manager DNS01 fails.** Confirm the cert-manager UMI was
+  provisioned by Crossplane (`bootstrap.crossplane.certManagerIdentity.enabled`
+  = true) and that Crossplane patched the cert-manager SA annotation.
+  The chart's `workloadIdentity.clientId` is intentionally left empty
+  for this reason.
+- **Release artifacts not publishing.** Check
+  `.github/workflows/release.yaml` and the chart-releaser
+  configuration. Confirm `Chart.yaml` version was bumped.
+
+## Contributing workflow
+
+1. Branch off `main`: `feat/<short-name>` or `docs/<short-name>`.
+2. Conventional Commit titles: `feat:`, `fix:`, `docs:`, `chore:`.
+3. Run `helm lint platform-core` and `helm template platform-core
+   ./platform-core` before pushing.
+4. Update value comments where you change defaults.
+5. Bump `platform-core/Chart.yaml` per SemVer for any chart-affecting
+   change.
+6. Open a PR back to `main`.
+
+See [`CONTRIBUTING.md`](../CONTRIBUTING.md) and
+[`PULL_REQUEST_TEMPLATE.md`](../.github/PULL_REQUEST_TEMPLATE.md) for
+the full checklist.


### PR DESCRIPTION
## Summary
Adds a `docs/` folder with user-guide and architecture documentation
for this repo.

## What's in the docs bundle
- `docs/README.md` — index + how to navigate
- `docs/overview.md` — what this repo is and when to touch it
- `docs/architecture.md` — how the pieces fit together
- `docs/user-guide.md` — day-to-day tasks and troubleshooting
- `docs/related-repos.md` — pointers to sibling DramisInfo repos

## Out of scope
- No source code, chart, template, or workflow changes.
- Related-repos list is canonical across the batch.
