### PR TITLE
fix(platform-core): whitelist k8s manifests in crossplane-compositions source

### DIFF
--- a/platform-core/templates/argo-applications/crossplane/crossplane-compositions.yaml
+++ b/platform-core/templates/argo-applications/crossplane/crossplane-compositions.yaml
@@ -21,6 +21,10 @@ spec:
       path: .
       directory:
         recurse: true
+        # Whitelist k8s manifests only. Without this, the directory generator
+        # mis-parses .release-please-manifest.json (valid JSON, no Kind) and
+        # the App has been stuck in ComparisonError since 2026-08-03.
+        include: '{compositions/**,*.yaml,*.yml}'
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## Problem

The platform-crossplane-compositions Application's directory generator (recurse=true) is failing with ComparisonError because it tries to parse every file in the repo, including `.release-please-manifest.json` which is valid JSON but has no Kind.

The app has been stuck since 2026-08-03 (commit 10d4b0c added the .release-please-manifest.json file). No composition revision can be picked up by the controller until this is fixed.

This also unblocks https://github.com/DramisInfo/platform-crossplane-compositions/pull/19 (added ghcr.io/actions/* to the AppProject sourceRepos for the ARC onboarding).

## Fix

Add an `include` pattern to the directory source that whitelists only the actual k8s manifests:

```yaml
directory:
  recurse: true
  include: '{compositions/**,*.yaml,*.yml}'
```

## Why this approach

- **Future-proof**: any new non-k8s file (release artifacts, docs, agent configs) is automatically excluded.
- **Reversible**: widening the include pattern is a one-character change.
- **No data loss**: no files are deleted or moved.
- **Local**: single-file change in one chart template.

## Test plan

1. Merge this PR.
2. Wait for the platform-core chart to re-render the Application.
3. Watch the platform-crossplane-compositions Application sync (should go from ComparisonError to Synced).
4. Verify that PR #19 in platform-crossplane-compositions is now picked up — a new composition revision `product-workspace-<hash>` is created with the ghcr.io/actions/* entry.
5. Verify the it-arcrunners-dev AppProject's sourceRepos list now includes ghcr.io/actions/*.
6. Verify the arc-controller and arc-scale-set Helm chart installs proceed.